### PR TITLE
bump to latest dr-svg-sprites npm module

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "async": "^0.8.0",
-    "dr-svg-sprites": "^0.9.4",
+    "dr-svg-sprites": "^0.9.6",
     "grunt": "^0.4.4",
     "grunt-contrib-jshint": "^0.7.2",
     "grunt-contrib-nodeunit": "^0.2.2"


### PR DESCRIPTION
Hey, don't mean to be a bother - using the responsive feature from `dr-svg-sprites` v0.9.6. Can we bump the version here?
